### PR TITLE
#33 Update Depreceated onActivityResult

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,13 +4,12 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.NOTIFICATION" />
-
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"
+                     android:minSdkVersion="33"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+                     android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+                     android:maxSdkVersion="32" />
 
 
     <application

--- a/app/src/main/java/com/example/cartoon/Helpers.kt
+++ b/app/src/main/java/com/example/cartoon/Helpers.kt
@@ -1,0 +1,18 @@
+package com.example.cartoon
+
+import android.Manifest
+import android.os.Build
+
+object Helpers {
+    fun requiredPermissions(): Array<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            //only on android 13 and above
+            arrayOf( Manifest.permission.POST_NOTIFICATIONS,
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
+        else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
+    }
+}

--- a/app/src/main/java/com/example/cartoon/Notification.kt
+++ b/app/src/main/java/com/example/cartoon/Notification.kt
@@ -1,7 +1,6 @@
 package com.example.cartoon
 
 import android.Manifest
-import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
@@ -9,11 +8,9 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import com.shashank.sony.fancytoastlib.FancyToast
 
 class Notification(private val context: Context) {
 
@@ -28,7 +25,7 @@ class Notification(private val context: Context) {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
             != PackageManager.PERMISSION_GRANTED
         ) {
-             requestNotificationPermission()
+              Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         } else {
             val notification = NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(title)
@@ -60,16 +57,5 @@ class Notification(private val context: Context) {
         }
     }
 
-    public fun requestNotificationPermission() {
-        ActivityCompat.requestPermissions(
-            context as Activity,
-            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-            PERMISSION_REQUEST_CODE
-        )
-    }
-
-    companion object {
-        private const val PERMISSION_REQUEST_CODE = 128956
-    }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Cartoon</string>
     <string name="cartoon">Cartoon</string>
+    <string name="msg_no_image_selected">No Image selected</string>
 </resources>


### PR DESCRIPTION
1. Use ActivityResult API for Selecting Image from device and Permissions.
2. Introduces READ_MEDIA_IMAGES permission , which is should be used instead of READ_EXTERNAL_STORAGE in android 13+ devices.
3. Cleanup old codes. 